### PR TITLE
Get twins owned by user

### DIFF
--- a/bin/lib/twins.js
+++ b/bin/lib/twins.js
@@ -176,11 +176,50 @@ function getAListOfAllOfTheAvailableTwins(){
     ;
 }
 
+function getAListOfAllOfTheAvailableTwinsOwnedByAUser(user){
+    
+    if(!user){
+        return Promise.reject("No user was passed to get twins for.");
+    }
+
+    const scanParameters = {
+        "selector": {
+            "owner": {
+                "$eq": user
+            }
+        }
+    };
+
+    return database.scan(scanParameters)
+        .then(documents => {
+
+            if(documents.length > 0){
+                
+                const sanitizedDocuments = documents.map(uncleanDocument => {return sanitizeDocument(uncleanDocument, twinsWhitelistProperties)});
+
+                return Promise.all(sanitizedDocuments);
+
+            } else {
+                return [];
+            }   
+
+        })
+        .catch(err => {
+            debug("Database scan error:", err);
+            throw err;
+        })
+    ;
+
+
+
+}
+
 module.exports = {
     get : getAnExistingTwinWithAnID,
     update : updateAnExistingTwinWithAGivenID,
     duplicate : duplicateAnExistingTwinWithAGivenID,
     create : createANewTwin,
     delete : deleteAnExistingTwinWithAGivenID,
-    list : getAListOfAllOfTheAvailableTwins
+    list : getAListOfAllOfTheAvailableTwins,
+    listByUser : getAListOfAllOfTheAvailableTwinsOwnedByAUser
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,16 +7,12 @@ const twins = require(`${__dirname}/../bin/lib/twins`);
 /* GET home page. */
 router.get('/', function(req, res, next) {
 
-	twins.list()
+	twins.listByUser(res.locals.w3id_userid)
 		.then(twins => {
 
 			debug("Stored Twins", JSON.stringify(twins));
 
-			twins = twins.filter( twin => {
-				
-				return twin.owner === res.locals.w3id_userid;
-
-			}).sort( (a, b) => {
+			twins = twins.sort( (a, b) => {
 
 				if(a.name > b.name){
 					return 1


### PR DESCRIPTION
We shouldn't be grabbing all of the twins and then filtering by the user. This will create a bottleneck in the future. Instead, we have a new function `getAListOfAllOfTheAvailableTwinsOwnedByAUser` in the twins interface which uses the Cloudant selector to only get the twins owned by a user.